### PR TITLE
Remove chooseAdvisorSchema

### DIFF
--- a/src/schemas/chooseAdvisorSchema/index.ts
+++ b/src/schemas/chooseAdvisorSchema/index.ts
@@ -1,2 +1,0 @@
-export * from './chooseAdvisorSchema';
-export { default } from './chooseAdvisorSchema';


### PR DESCRIPTION
The "chooseAdvisorSchema" file within src/schemas has been deleted as it is no longer needed in the application. Any references to this schema in other files should be updated or removed accordingly.